### PR TITLE
Set up Cursor Cloud dev environment for net4cpp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`net4cpp` is a single **C++23 modules** networking + HTTP library (no databases, no
+long-running services). It builds to prebuilt module files (`.pcm`), object files, and a
+test runner binary. There is no npm/pip/cargo — the only external dependency is the
+`deps/tester` git submodule (test framework + build core), fetched by the update script.
+
+### Toolchain
+- Requires **Clang/LLVM 21** with **libc++** (`clang++-21`, `libc++-21-dev`,
+  `libc++abi-21-dev`, `lld-21`, plus `clang-tidy-21`/`cppcheck` for lint). These are
+  installed in the VM image; the update script only refreshes the `deps/tester` submodule.
+- `tools/CB.sh` hardcodes `clang++-21` and `/usr/lib/llvm-21` (it ignores `CXX`), so you do
+  not need to export `CC`/`CXX`/`LDFLAGS`.
+
+### Build / test / lint (see `README.md` for the full story)
+- Build: `./tools/CB.sh debug build` (or `release`).
+- Test: `./tools/CB.sh debug test`.
+- Lint (non-blocking, mirrors `.github/workflows/ci.yml`): `cppcheck` over `net/ tools/`,
+  and `clang-tidy-21 <file> -- -std=c++23 -I/usr/lib/llvm-21/include/c++/v1`. Note
+  `clang-tidy` reports `module 'std' not found` on the `import std;` line — this is
+  expected (clang-tidy doesn't consume the prebuilt `std.pcm`) and CI treats it as
+  non-blocking.
+
+### Network tests — important gotcha
+- `tools/CB.sh` only auto-sets `NET_DISABLE_NETWORK_TESTS=1` when the `CURSOR_SANDBOX`
+  env var is present. In this cloud environment `CURSOR_SANDBOX` is **not** set, so network
+  tests run by default and a couple fail against the restricted sandbox network (e.g.
+  `net-posix.test.c++` connect-timeout to a non-routable IP, `net-socket.test.c++`
+  `wait_for`). These are environment limitations, not code bugs.
+- For a clean, fully-green run use: `NET_DISABLE_NETWORK_TESTS=1 ./tools/CB.sh debug test`
+  (393/393 tests pass). **Loopback** (`::1` / `127.0.0.1`) networking does work, so
+  echo/HTTP-over-loopback demos run fine.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for `net4cpp` (a C++23 modules networking/HTTP library) in Cursor Cloud and documents the non-obvious startup caveats for future agents.

## What was done

- Installed the **LLVM 21 toolchain** (`clang-21`, `libc++-21-dev`, `libc++abi-21-dev`, `lld-21`, `clang-tools-21`, `clang-tidy-21`, `cppcheck`, `libssl-dev`) from apt.llvm.org — only `clang 18` was present. Baked into the VM image.
- Initialized the `deps/tester` git submodule (test framework + build core; the project's only external dependency).
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing the key gotcha (see below).

## Update script

`git submodule update --init --depth 1 deps/tester`

Minimal, idempotent dependency refresh. The LLVM toolchain lives in the VM image, so it is not reinstalled per session.

## Verified working

| Task | Command | Result |
|---|---|---|
| Build | `./tools/CB.sh debug build` | SUCCESS |
| Test | `NET_DISABLE_NETWORK_TESTS=1 ./tools/CB.sh debug test` | 393/393 tests, 881/881 assertions pass |
| Lint | `cppcheck ... net/ tools/` + `clang-tidy-21` | runs (non-blocking, matches CI) |
| Hello-world | echo server + client over IPv6 loopback (`net::acceptor` / `net::connect`) | `Hello, net4cpp!` echoed back |

## Key gotcha (documented in AGENTS.md)

`tools/CB.sh` only auto-disables network tests when `CURSOR_SANDBOX` is set, which it is **not** in this cloud environment. So network tests run by default and a few fail against the restricted sandbox network. Use `NET_DISABLE_NETWORK_TESTS=1` for a fully-green run. Loopback networking works, so echo/HTTP demos run fine.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4121c3c8-9eea-432d-9110-3939c4bd454d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4121c3c8-9eea-432d-9110-3939c4bd454d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

