### PR TITLE
feat: enforce WebSocket client masking + add uncovered-case tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ Upgrade is handled inside `http::server` (not as response middleware). Register 
 with `server.ws(...).ws(handler)`; a matching `GET` with `Upgrade: websocket` returns
 `101` and runs a text-frame session (ping/pong/close + optional text replies).
 
+Per RFC 6455 §5.1, client-to-server frames must be masked; an unmasked frame is
+rejected with a `1002` (protocol error) close and ends the session.
+
 ```cpp
 import net;
 import std;

--- a/net/net-websocket.c++m
+++ b/net/net-websocket.c++m
@@ -146,6 +146,14 @@ inline void run_text_session(std::iostream& stream, const text_handler& on_text)
         if(not read_frame(stream, incoming))
             break;
 
+        // RFC 6455 §5.1: every client-to-server frame MUST be masked. Reject an
+        // unmasked frame with a 1002 (protocol error) close and end the session.
+        if(not incoming.masked)
+        {
+            write_frame(stream, make_close_frame(close_protocol_error));
+            return;
+        }
+
         switch(incoming.op)
         {
         case opcode::ping:

--- a/net/net-websocket.test.c++
+++ b/net/net-websocket.test.c++
@@ -260,6 +260,31 @@ auto register_websocket_tests()
         check_true(not read_frame(out, extra)); // nothing echoed after close
     };
 
+    tester::bdd::scenario("run_text_session rejects unmasked client frame with 1002, [net]") = [] {
+        // RFC 6455 §5.1: client frames must be masked. An unmasked text frame must
+        // be rejected with a protocol-error close and the handler must not run.
+        auto handler_ran = std::make_shared<bool>(false);
+        auto stream = duplex_stream{frame_bytes(make_text_frame("nomask"sv))};
+        run_text_session(stream, [handler_ran](std::string_view msg) -> std::optional<std::string> {
+            *handler_ran = true;
+            return std::string{msg};
+        });
+
+        auto out = std::istringstream{stream.output()};
+        auto reply = frame{};
+        require_true(read_frame(out, reply));
+        check_eq(reply.op, opcode::close);
+        require_true(reply.payload.size() >= 2);
+        const auto code = static_cast<std::uint16_t>(
+            (std::to_integer<unsigned>(reply.payload[0]) << 8)
+            | std::to_integer<unsigned>(reply.payload[1]));
+        check_eq(code, close_protocol_error);
+        check_true(not *handler_ran);
+
+        auto extra = frame{};
+        check_true(not read_frame(out, extra)); // session ended after the close
+    };
+
     tester::bdd::scenario("http server websocket echo upgrade, [net]") = [] {
         if(not network_tests_enabled())
             return;

--- a/net/net-websocket.test.c++
+++ b/net/net-websocket.test.c++
@@ -36,6 +36,88 @@ inline frame make_masked_close(std::uint32_t key = 0x01020304u)
     return f;
 }
 
+inline frame make_masked_ping(std::string_view payload, std::uint32_t key = 0x01020304u)
+{
+    auto f = frame{};
+    f.op = opcode::ping;
+    f.masked = true;
+    f.masking_key = key;
+    f.payload.resize(payload.size());
+    if(not payload.empty())
+        std::memcpy(f.payload.data(), payload.data(), payload.size());
+    return f;
+}
+
+inline frame make_masked_pong(std::uint32_t key = 0x01020304u)
+{
+    auto f = frame{};
+    f.op = opcode::pong;
+    f.masked = true;
+    f.masking_key = key;
+    return f;
+}
+
+// In-memory duplex stream: reads consume a prepared input buffer, writes are
+// captured separately so run_text_session responses can be inspected without a
+// socket. Keeping the two directions apart avoids the reader looping over freshly
+// written response bytes (which a single shared buffer would do).
+class duplex_buf : public std::streambuf
+{
+public:
+
+    explicit duplex_buf(std::string input) : m_in{std::move(input)}
+    {
+        auto* base = m_in.data();
+        setg(base, base, base + m_in.size());
+    }
+
+    const std::string& output() const noexcept { return m_out; }
+
+protected:
+
+    int_type overflow(int_type ch) override
+    {
+        if(ch != traits_type::eof())
+            m_out.push_back(static_cast<char>(ch));
+        return ch;
+    }
+
+    std::streamsize xsputn(const char* s, std::streamsize n) override
+    {
+        m_out.append(s, static_cast<std::size_t>(n));
+        return n;
+    }
+
+private:
+
+    std::string m_in;
+    std::string m_out;
+};
+
+class duplex_stream : public std::iostream
+{
+public:
+
+    explicit duplex_stream(std::string input) : std::iostream{nullptr}, m_buf{std::move(input)}
+    {
+        rdbuf(&m_buf);
+    }
+
+    const std::string& output() const noexcept { return m_buf.output(); }
+
+private:
+
+    duplex_buf m_buf;
+};
+
+// Encode a frame to bytes for use as duplex_stream input.
+inline std::string frame_bytes(const frame& f)
+{
+    auto oss = std::ostringstream{};
+    write_frame(oss, f);
+    return oss.str();
+}
+
 } // namespace
 
 auto register_websocket_tests()
@@ -67,6 +149,115 @@ auto register_websocket_tests()
         auto decoded = frame{};
         require_true(read_frame(iss, decoded));
         check_eq(payload_as_string(decoded), payload);
+    };
+
+    tester::bdd::scenario("websocket unmasked server frame round-trip, [net]") = [] {
+        auto oss = std::ostringstream{};
+        require_true(write_frame(oss, make_text_frame("server-say"sv)));
+
+        auto iss = std::istringstream{oss.str()};
+        auto decoded = frame{};
+        require_true(read_frame(iss, decoded));
+        check_true(not decoded.masked);
+        check_eq(decoded.op, opcode::text);
+        check_eq(payload_as_string(decoded), "server-say"s);
+    };
+
+    tester::bdd::scenario("websocket frame supports 64-bit extended length, [net]") = [] {
+        // > 0xFFFF forces the 8-byte length encoding, still under the 1 MiB cap.
+        const auto payload = std::string(70000, 'y');
+        auto oss = std::ostringstream{};
+        require_true(write_frame(oss, make_masked_text(payload)));
+
+        auto iss = std::istringstream{oss.str()};
+        auto decoded = frame{};
+        require_true(read_frame(iss, decoded));
+        check_eq(decoded.payload.size(), payload.size());
+        check_eq(payload_as_string(decoded), payload);
+    };
+
+    tester::bdd::scenario("websocket read_frame rejects oversized payload, [net]") = [] {
+        // Hand-craft a header that claims > 1 MiB via the 64-bit length field.
+        auto header = std::string{};
+        header.push_back(static_cast<char>(0x81)); // FIN + text
+        header.push_back(static_cast<char>(0x7F)); // 127 => 64-bit length, unmasked
+        const auto len = std::uint64_t{(1u << 20) + 1};
+        for(int shift = 56; shift >= 0; shift -= 8)
+            header.push_back(static_cast<char>((len >> shift) & 0xFFu));
+
+        auto iss = std::istringstream{header};
+        auto decoded = frame{};
+        check_true(not read_frame(iss, decoded));
+    };
+
+    tester::bdd::scenario("websocket read_frame fails on truncated payload, [net]") = [] {
+        // Announce 5 bytes but only provide 2.
+        auto oss = std::ostringstream{};
+        require_true(write_frame(oss, make_masked_text("hello"sv)));
+        auto truncated = oss.str().substr(0, oss.str().size() - 3);
+
+        auto iss = std::istringstream{truncated};
+        auto decoded = frame{};
+        check_true(not read_frame(iss, decoded));
+    };
+
+    tester::bdd::scenario("run_text_session echoes text via handler, [net]") = [] {
+        auto stream = duplex_stream{frame_bytes(make_masked_text("hello"sv))};
+        run_text_session(stream, [](std::string_view msg) -> std::optional<std::string> {
+            return std::string{msg} + "!";
+        });
+
+        auto out = std::istringstream{stream.output()};
+        auto reply = frame{};
+        require_true(read_frame(out, reply));
+        check_true(not reply.masked);
+        check_eq(reply.op, opcode::text);
+        check_eq(payload_as_string(reply), "hello!"s);
+    };
+
+    tester::bdd::scenario("run_text_session suppresses reply when handler returns nullopt, [net]") = [] {
+        auto stream = duplex_stream{frame_bytes(make_masked_text("quiet"sv))};
+        run_text_session(stream, [](std::string_view) -> std::optional<std::string> {
+            return std::nullopt;
+        });
+        check_true(stream.output().empty());
+    };
+
+    tester::bdd::scenario("run_text_session answers ping with pong, [net]") = [] {
+        auto stream = duplex_stream{frame_bytes(make_masked_ping("hb"sv))};
+        run_text_session(stream, nullptr);
+
+        auto out = std::istringstream{stream.output()};
+        auto reply = frame{};
+        require_true(read_frame(out, reply));
+        check_eq(reply.op, opcode::pong);
+        check_eq(payload_as_string(reply), "hb"s);
+    };
+
+    tester::bdd::scenario("run_text_session ignores pong frames, [net]") = [] {
+        auto stream = duplex_stream{frame_bytes(make_masked_pong())};
+        run_text_session(stream, nullptr);
+        check_true(stream.output().empty());
+    };
+
+    tester::bdd::scenario("run_text_session replies to close and ends, [net]") = [] {
+        // A close frame followed by a text frame: the session must stop after the
+        // close and never echo the trailing text.
+        auto input = frame_bytes(make_masked_close());
+        input += frame_bytes(make_masked_text("after-close"sv));
+
+        auto stream = duplex_stream{input};
+        run_text_session(stream, [](std::string_view msg) -> std::optional<std::string> {
+            return std::string{msg};
+        });
+
+        auto out = std::istringstream{stream.output()};
+        auto reply = frame{};
+        require_true(read_frame(out, reply));
+        check_eq(reply.op, opcode::close);
+
+        auto extra = frame{};
+        check_true(not read_frame(out, extra)); // nothing echoed after close
     };
 
     tester::bdd::scenario("http server websocket echo upgrade, [net]") = [] {

--- a/net/net-websocket_frame.c++m
+++ b/net/net-websocket_frame.c++m
@@ -18,6 +18,10 @@ enum class opcode : std::uint8_t
     pong = 0xA,
 };
 
+// RFC 6455 §7.4.1 close status codes (subset used by this server).
+inline constexpr std::uint16_t close_normal = 1000;
+inline constexpr std::uint16_t close_protocol_error = 1002;
+
 struct frame
 {
     bool fin = true;
@@ -52,6 +56,17 @@ inline frame make_close_frame(std::span<const std::byte> payload = {})
     auto f = frame{};
     f.op = opcode::close;
     f.payload.assign(payload.begin(), payload.end());
+    return f;
+}
+
+// Close frame carrying a 2-byte big-endian status code (RFC 6455 §5.5.1).
+inline frame make_close_frame(std::uint16_t status_code)
+{
+    auto f = frame{};
+    f.op = opcode::close;
+    f.payload.resize(2);
+    f.payload[0] = static_cast<std::byte>((status_code >> 8) & 0xFFu);
+    f.payload[1] = static_cast<std::byte>(status_code & 0xFFu);
     return f;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Builds on `feat/websocket` (base is the feature branch, not `master`). Two related pieces:

1. **Fix:** enforce RFC 6455 §5.1 — the server now rejects unmasked client-to-server frames.
2. **Tests:** cover the previously-uncovered WebSocket frame and session paths.

## Mask enforcement (production)

- `run_text_session` now rejects any unmasked incoming frame with a `1002` (protocol error) Close and ends the session, before running the handler (`net/net-websocket.c++m`).
- Added close status-code constants (`close_normal`, `close_protocol_error`) and a `make_close_frame(std::uint16_t)` overload that carries a 2-byte big-endian code (`net/net-websocket_frame.c++m`).
- Documented the behavior in the `README.md` WebSocket section.

## New tests (`net/net-websocket.test.c++`)

All network-free — they drive `run_text_session` through a small in-memory duplex stream helper (reads from a prepared buffer, captures writes separately), so they execute even when `NET_DISABLE_NETWORK_TESTS=1`.

Frame layer:
- unmasked server frame round-trip
- 64-bit extended length frame (payload > 0xFFFF)
- `read_frame` rejects oversized payload (> 1 MiB cap)
- `read_frame` fails on truncated payload

Session layer (`run_text_session`):
- echoes text via handler
- suppresses reply when handler returns `nullopt`
- answers ping with pong (same payload)
- ignores pong frames
- replies to close and terminates without echoing trailing frames
- **rejects an unmasked client frame with a 1002 close and does not run the handler**

## Verification

`NET_DISABLE_NETWORK_TESTS=1 ./tools/CB.sh debug test`

```
tests:      403/403 passed (100.0%) | failed: 0
assertions: 918/918 passed (100.0%) | failed: 0
SUCCESS All tests passed!
```

A full run (network enabled) also keeps the loopback echo-upgrade test green — masked client frames still work with enforcement active; the only failures are the two pre-existing environment-limited tests (`net-posix`, `net-socket`), unrelated to this change.

[WebSocket mask enforcement + coverage test output](https://cursor.com/agents/bc-4121c3c8-9eea-432d-9110-3939c4bd454d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwebsocket_mask_enforcement_output.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4121c3c8-9eea-432d-9110-3939c4bd454d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4121c3c8-9eea-432d-9110-3939c4bd454d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

