### PR TITLE
fix: dispatch CORS OPTIONS preflight to route handlers

### DIFF
--- a/net/net-http_server.c++m
+++ b/net/net-http_server.c++m
@@ -910,14 +910,82 @@ private:
                             }
                         }
 
-                    // Handle OPTIONS preflight requests - if no route found, return 204 with empty body
-                    // CORS middleware will add CORS headers if configured
+                    // OPTIONS with no matching path: 204. (No handler runs, so
+                    // cors_middleware cannot attach ACAO here.)
                     if(method == method_options and not route_found and res_type.empty())
                     {
                         res_status = status_no_content;
                         res_content = "";
                         res_type = m_content_type;
                         custom_headers = std::nullopt;
+                    }
+                    // CORS preflight to an existing path: there is no options()
+                    // registrar, so OPTIONS never matches methods_map and would
+                    // otherwise 405 before cors_middleware can short-circuit.
+                    // Dispatch to a registered method handler on that path so a
+                    // wrapping cors_middleware sees Access-Control-Request-Method
+                    // and returns 204 + ACAO without running the inner handler.
+                    else if(method == method_options and route_found and not method_allowed
+                        and res_type.empty() and hs.contains("access-control-request-method"))
+                    {
+                        for(const auto& [path, methods_map] : m_router)
+                        {
+                            if(not std::regex_match(std::string{uri}, std::regex{path}))
+                                continue;
+
+                            // Prefer GET/POST (typical cors_middleware wrap targets).
+                            // Skip method_ws — those controllers have no HTTP callback chain.
+                            auto it = methods_map.find(method_get);
+                            if(it == methods_map.end())
+                                it = methods_map.find(method_post);
+                            if(it == methods_map.end())
+                            {
+                                for(auto cand = methods_map.begin(); cand != methods_map.end(); ++cand)
+                                {
+                                    if(cand->first != method_ws)
+                                    {
+                                        it = cand;
+                                        break;
+                                    }
+                                }
+                            }
+                            if(it == methods_map.end())
+                                continue;
+
+                            try
+                            {
+                                hs.set("x-http-method"s, method);
+                                std::tie(res_status, res_content, res_type, custom_headers) =
+                                    it->second.render(uri, body, hs);
+                                break;
+                            }
+                            catch(const std::exception& e)
+                            {
+                                const auto request_duration = duration_cast<milliseconds>(system_clock::now() - request_start).count();
+                                net::slog << net::error("HTTP_HANDLER_EXCEPTION") << "exception in OPTIONS preflight dispatch for \"" << uri << "\" (route: " << path << "): " << e.what()
+                                          << std::pair{"ip"sv, endpoint}
+                                          << std::pair{"port", port}
+                                          << std::pair{"method", method}
+                                          << std::pair{"uri", std::string{uri}}
+                                          << std::pair{"route", path}
+                                          << std::pair{"status", status_internal_server_error}
+                                          << std::pair{"request_id", request_id}
+                                          << std::pair{"duration_ms", request_duration}
+                                          << net::flush;
+                                res_status = status_internal_server_error;
+                                res_content = "";
+                                res_type = m_content_type;
+                                custom_headers = std::nullopt;
+                                break;
+                            }
+                        }
+                        if(res_type.empty())
+                        {
+                            res_status = status_no_content;
+                            res_content = "";
+                            res_type = m_content_type;
+                            custom_headers = std::nullopt;
+                        }
                     }
                     // If route found but method not allowed, return 405 Method Not Allowed
                     else if(route_found and not method_allowed and res_type.empty())

--- a/net/net-http_server.test.c++
+++ b/net/net-http_server.test.c++
@@ -1296,6 +1296,102 @@ auto register_server_tests()
         };
     };
 
+    // Regression: OPTIONS preflight to a registered POST/GET path used to 405
+    // before cors_middleware could short-circuit (no options() registrar).
+    tester::bdd::scenario("OPTIONS CORS preflight reaches cors_middleware on existing routes, [net]") = [] {
+        if(not network_tests_enabled()) return;
+
+        tester::bdd::given("An HTTP server with a POST route wrapped in cors_middleware") = [] {
+            auto server = std::make_shared<http::server>();
+            auto handler_invoked = std::make_shared<std::atomic<bool>>(false);
+
+            auto allowed_origin = [](std::string_view origin) {
+                return origin == "http://localhost:8080"sv;
+            };
+            auto cors_mw = http::middleware::cors_middleware(
+                allowed_origin,
+                std::vector<std::string>{"GET"s, "POST"s, "OPTIONS"s},
+                std::vector<std::string>{"Content-Type"s, "Authorization"s},
+                true,
+                std::optional<int>{3600});
+
+            auto post_handler = [handler_invoked](auto&&, auto&&, auto&&) -> http::response_with_headers {
+                handler_invoked->store(true);
+                return http::make_response(http::status_created, "Created"s, std::optional<http::headers>{});
+            };
+            server->post("/api/data").response_with_headers("application/json", cors_mw(post_handler));
+            server->timeout(std::chrono::seconds{1});
+
+            tester::bdd::when("Browser-style OPTIONS preflight is sent to the POST route") = [server, handler_invoked] {
+                auto response_status = std::make_shared<std::string>("");
+                auto acao = std::make_shared<std::string>("");
+                auto acam = std::make_shared<std::string>("");
+
+                std::promise<void> started;
+                auto started_future = started.get_future();
+
+                std::thread server_thread{[server, &started]{
+                    try {
+                        started.set_value();
+                        server->listen("8094");
+                    } catch(...) {}
+                }};
+
+                using namespace std::chrono_literals;
+                if (started_future.wait_for(2s) == std::future_status::ready) {
+                    std::this_thread::sleep_for(200ms);
+
+                    try {
+                        auto stream = connect("127.0.0.1", "8094");
+                        stream << "OPTIONS /api/data HTTP/1.1" << net::crlf
+                               << "Host: 127.0.0.1:8094" << net::crlf
+                               << "Origin: http://localhost:8080" << net::crlf
+                               << "Access-Control-Request-Method: POST" << net::crlf
+                               << "Access-Control-Request-Headers: content-type,authorization" << net::crlf
+                               << "Connection: close" << net::crlf
+                               << net::crlf
+                               << net::flush;
+
+                        std::string line;
+                        int line_count = 0;
+                        while(line_count < 30 and stream and std::getline(stream, line)) {
+                            if(not line.empty() and line.back() == '\r')
+                                line.pop_back();
+                            ++line_count;
+                            if(line_count == 1) {
+                                auto space1 = line.find(' ');
+                                if(space1 != std::string::npos) {
+                                    auto space2 = line.find(' ', space1 + 1);
+                                    *response_status = space2 != std::string::npos
+                                        ? line.substr(space1 + 1, space2 - space1 - 1)
+                                        : line.substr(space1 + 1);
+                                }
+                            } else if(line.starts_with("access-control-allow-origin:"sv)) {
+                                *acao = std::string{utils::trim(std::string_view{line}.substr(line.find(':') + 1))};
+                            } else if(line.starts_with("access-control-allow-methods:"sv)) {
+                                *acam = std::string{utils::trim(std::string_view{line}.substr(line.find(':') + 1))};
+                            }
+                            if(line.empty()) break;
+                        }
+                    } catch(...) {}
+
+                    std::this_thread::sleep_for(200ms);
+                    server->stop();
+                }
+
+                if (server_thread.joinable()) server_thread.join();
+
+                tester::bdd::then("Response is 204 with CORS headers and POST handler is not run") =
+                    [response_status, acao, acam, handler_invoked] {
+                        check_eq(*response_status, "204");
+                        check_eq(*acao, "http://localhost:8080");
+                        check_true(acam->contains("POST"));
+                        check_false(handler_invoked->load());
+                    };
+            };
+        };
+    };
+
     return true;
 }
 


### PR DESCRIPTION
## Summary
- `http::server` has no `options()` registrar, so OPTIONS to a registered GET/POST path always 405'd before `cors_middleware` could short-circuit.
- When `Access-Control-Request-Method` is present, dispatch to a GET/POST (or other non-WS) handler on the matched path so wrapping `cors_middleware` can answer 204.

Split from [#37](https://github.com/ruoka/net4cpp/pull/37).

## Test plan
- [x] `./tools/CB.sh debug test "OPTIONS CORS" --jsonl=failures`
- [x] Rebased onto master including the request-head size cap

Made with [Cursor](https://cursor.com)