### PR TITLE
feat: wake http::server::stop by closing listen sockets

### DIFF
--- a/net/net-acceptor.c++m
+++ b/net/net-acceptor.c++m
@@ -113,7 +113,13 @@ public:
         auto sas = posix::sockaddr_storage{};
         auto saslen = posix::socklen_t{sizeof sas};
         socket s = posix::accept(fd, reinterpret_cast<posix::sockaddr*>(&sas), &saslen);
-        if(not s) throw std::system_error{posix::get_errno(), std::system_category(),"accept failed"};
+        if(not s)
+        {
+            const auto err = posix::get_errno();
+            if(err == posix::ebadf or closed())
+                throw std::system_error{posix::ebadf, std::system_category(), "acceptor closed"};
+            throw std::system_error{err, std::system_category(), "accept failed"};
+        }
 
         char hbuf[posix::ni_maxhost];
         char sbuf[posix::ni_maxserv];
@@ -123,6 +129,24 @@ public:
         return {new endpointbuf<tcp_buffer_size>{std::move(s)}, hbuf, sbuf};
     }
 
+    // Close all listen sockets so a concurrent accept()/select wakes promptly.
+    // Thread-safe: intended to be called from another thread (e.g. http::server::stop).
+    // After close, accept() fails with EBADF / "acceptor closed" (and may surface as
+    // EINTR/EBADF from select while the close races the wait). Idempotent.
+    void close() noexcept
+    {
+        std::lock_guard lock{m_mutex};
+        m_closed = true;
+        for(auto& s : m_sockets)
+            s.close();
+    }
+
+    bool closed() const noexcept
+    {
+        std::lock_guard lock{m_mutex};
+        return m_closed;
+    }
+
     const auto& host() const { return m_host; }
     const auto& service_or_port() const { return m_service_or_port; }
     const auto& timeout() const { return m_timeout; }
@@ -130,15 +154,17 @@ public:
 
     std::uint16_t bound_port() const
     {
-        if (m_sockets.empty()) return 0;
+        std::lock_guard lock{m_mutex};
+        if(m_sockets.empty()) return 0;
         auto sas = posix::sockaddr_storage{};
         auto saslen = posix::socklen_t{sizeof sas};
-        if (posix::getsockname(m_sockets.front(), reinterpret_cast<posix::sockaddr*>(&sas), &saslen) == -1)
+        const int fd = m_sockets.front();
+        if(fd < 0 or posix::getsockname(fd, reinterpret_cast<posix::sockaddr*>(&sas), &saslen) == -1)
             return 0;
-        
-        if (sas.ss_family == posix::af_inet)
+
+        if(sas.ss_family == posix::af_inet)
             return posix::ntohs(reinterpret_cast<posix::sockaddr_in*>(&sas)->sin_port);
-        if (sas.ss_family == posix::af_inet6)
+        if(sas.ss_family == posix::af_inet6)
             return posix::ntohs(reinterpret_cast<posix::sockaddr_in6*>(&sas)->sin6_port);
         return 0;
     }
@@ -146,12 +172,13 @@ public:
 private:
     int wait()
     {
-        // select() may return -1 (e.g. EINTR). On error the fd_set is left
-        // unmodified on Linux/macOS — still containing every listener we set —
-        // so treating any non-zero return as "ready" falsely wakes accept()
+        // select() may return -1 (e.g. EINTR, EBADF after close()). On error the
+        // fd_set is left unmodified on Linux/macOS — still containing every listener
+        // we set — so treating any non-zero return as "ready" falsely wakes accept()
         // and blocks forever with no pending connection (bypassing timeout /
-        // http::server stop polling). Retry EINTR; fail other errors; only
-        // inspect readiness bits when select reports ready > 0.
+        // http::server stop polling). Retry EINTR while open; treat EBADF / closed
+        // as stop; fail other errors; only inspect readiness bits when select
+        // reports ready > 0.
         using clock = std::chrono::steady_clock;
         const auto deadline = m_timeout.count()
             ? clock::now() + m_timeout
@@ -159,12 +186,27 @@ private:
 
         for(;;)
         {
-            posix::fd_set fds{};
-            posix::fd_zero(&fds);
-            int max_fd = -1;
-            for(int fd : m_sockets)
+            std::vector<int> fds;
             {
-                posix::fd_set_bit(fd, &fds);
+                std::lock_guard lock{m_mutex};
+                if(m_closed)
+                    throw std::system_error{posix::ebadf, std::system_category(), "acceptor closed"};
+                fds.reserve(m_sockets.size());
+                for(int fd : m_sockets)
+                {
+                    if(fd >= 0)
+                        fds.push_back(fd);
+                }
+                if(fds.empty())
+                    throw std::system_error{posix::ebadf, std::system_category(), "acceptor closed"};
+            }
+
+            posix::fd_set set{};
+            posix::fd_zero(&set);
+            int max_fd = -1;
+            for(int fd : fds)
+            {
+                posix::fd_set_bit(fd, &set);
                 if(fd > max_fd)
                     max_fd = fd;
             }
@@ -184,19 +226,35 @@ private:
                 tv_ptr = &tv;
             }
 
-            const auto ready = posix::select(max_fd + 1, &fds, nullptr, nullptr, tv_ptr);
+            const auto ready = posix::select(max_fd + 1, &set, nullptr, nullptr, tv_ptr);
             if(ready < 0)
             {
-                if(posix::get_errno() == posix::eintr)
+                const auto err = posix::get_errno();
+                if(err == posix::eintr)
+                {
+                    // EINTR: retry unless stop closed the listeners (document as stop).
+                    if(closed())
+                        throw std::system_error{posix::ebadf, std::system_category(), "acceptor closed"};
                     continue;
-                throw std::system_error{posix::get_errno(), std::system_category(), "accept failed"};
+                }
+                if(err == posix::ebadf or closed())
+                    throw std::system_error{posix::ebadf, std::system_category(), "acceptor closed"};
+                throw std::system_error{err, std::system_category(), "accept failed"};
             }
             if(ready == 0)
+            {
+                if(closed())
+                    throw std::system_error{posix::ebadf, std::system_category(), "acceptor closed"};
                 throw std::system_error{posix::etimedout, std::system_category(), "accept timeouted"};
+            }
 
-            for(int fd : m_sockets)
-                if(posix::fd_isset(fd, &fds))
+            for(int fd : fds)
+            {
+                if(posix::fd_isset(fd, &set))
                     return fd;
+            }
+            if(closed())
+                throw std::system_error{posix::ebadf, std::system_category(), "acceptor closed"};
             throw std::system_error{posix::get_errno(), std::system_category(), "accept failed"};
         }
     }
@@ -205,6 +263,8 @@ private:
     std::string m_service_or_port;
     std::chrono::milliseconds m_timeout;
     std::list<socket> m_sockets;
+    mutable std::mutex m_mutex;
+    bool m_closed{false};
 };
 
 } // namespace net

--- a/net/net-acceptor.test.c++
+++ b/net/net-acceptor.test.c++
@@ -76,6 +76,42 @@ auto register_acceptor_tests()
         check_true(std::chrono::steady_clock::now() - start < 2s);
     };
 
+    tester::bdd::scenario("close wakes accept wait promptly, [net]") = [] {
+        using namespace std::chrono_literals;
+        auto ator = std::make_shared<net::acceptor>("127.0.0.1", "0");
+        // Long timeout: without close()-wake this would sit ~30s.
+        ator->timeout(30s);
+        auto accept_error = std::make_shared<std::optional<std::system_error>>();
+        std::promise<void> entered;
+        auto entered_future = entered.get_future();
+
+        std::thread t{[ator, accept_error, &entered] {
+            entered.set_value();
+            try
+            {
+                (void)ator->accept();
+            }
+            catch(const std::system_error& e)
+            {
+                *accept_error = e;
+            }
+        }};
+
+        check_true(entered_future.wait_for(2s) == std::future_status::ready);
+        std::this_thread::sleep_for(50ms);
+        const auto start = std::chrono::steady_clock::now();
+        ator->close();
+        t.join();
+        const auto elapsed = std::chrono::steady_clock::now() - start;
+
+        check_true(ator->closed());
+        check_true(accept_error->has_value());
+        check_true(
+            (*accept_error)->code() == std::errc::bad_file_descriptor
+            or std::string_view{(*accept_error)->what()}.contains("acceptor closed"));
+        check_true(elapsed < 500ms);
+    };
+
     tester::bdd::scenario("Basic construction, [net]") = [] {
         tester::bdd::given("An acceptor for localhost:54321") = [] {
             auto ator = net::acceptor{"localhost","54321"};

--- a/net/net-http_server.c++m
+++ b/net/net-http_server.c++m
@@ -264,29 +264,54 @@ public:
                   << net::flush;
         try
         {
-            auto endpoint = net::acceptor{host, service_or_port};
+            auto endpoint = std::make_shared<net::acceptor>(host, service_or_port);
+            {
+                std::lock_guard lock{m_acceptor_mutex};
+                m_acceptor = endpoint;
+            }
+            // Drop the shared slot when listen returns (normal stop or error),
+            // so a late stop() cannot close a recycled acceptor.
+            struct release_acceptor
+            {
+                server* self;
+                ~release_acceptor()
+                {
+                    std::lock_guard lock{self->m_acceptor_mutex};
+                    self->m_acceptor.reset();
+                }
+            } release{this};
+
             auto check_timeout = m_timeout.count() ? m_timeout : std::chrono::seconds{1};
-            endpoint.timeout(std::chrono::milliseconds{check_timeout.count() * 1000});
-            net::slog << net::notice("HTTP_SERVER_READY") << "started up at " << endpoint.host() << ":" << endpoint.service_or_port()
-                      << std::pair{"addr", endpoint.host()}
-                      << std::pair{"port", endpoint.service_or_port()}
+            endpoint->timeout(std::chrono::milliseconds{check_timeout.count() * 1000});
+            net::slog << net::notice("HTTP_SERVER_READY") << "started up at " << endpoint->host() << ":" << endpoint->service_or_port()
+                      << std::pair{"addr", endpoint->host()}
+                      << std::pair{"port", endpoint->service_or_port()}
                       << net::flush;
             if(on_bound)
                 on_bound();
-            
+
             while(not m_stop.load())
             {
                 try
                 {
                     using namespace std::string_view_literals;
-                    net::slog << net::debug("HTTP_ACCEPT_WAIT") 
+                    net::slog << net::debug("HTTP_ACCEPT_WAIT")
                               << std::pair{"protocol"sv, "http"sv}
                               << "waiting for HTTP connections" << net::flush;
-                    auto client = endpoint.accept();
+                    auto client = endpoint->accept();
                     std::thread{[client_data = std::move(client), this]() mutable { handle(client_data); }}.detach();
                 }
                 catch(const std::system_error& e)
                 {
+                    // stop() closes listen fds so select/accept wakes with
+                    // EBADF / "acceptor closed" (or EINTR racing close). Treat
+                    // post-stop accept errors as a clean exit, not fatal.
+                    if(m_stop.load()
+                        or e.code().value() == net::posix::ebadf
+                        or std::string_view{e.what()}.contains("acceptor closed"))
+                    {
+                        break;
+                    }
                     if(std::string_view{e.what()}.contains("timeout"))
                     {
                         continue;
@@ -298,6 +323,8 @@ public:
                 }
                 catch(const std::exception& e)
                 {
+                    if(m_stop.load())
+                        break;
                     net::slog << net::error("HTTP_ACCEPT_EXCEPTION") << "exception while accepting connection: " << e.what() << net::flush;
                     throw;
                 }
@@ -357,9 +384,18 @@ public:
         m_max_request_head_size = bytes;
     }
 
+    // Signal the listen loop to exit and close listen sockets so accept wait
+    // wakes immediately (Docker SIGTERM / join). Thread-safe vs listen().
     void stop()
     {
         m_stop.store(true);
+        std::shared_ptr<net::acceptor> acceptor;
+        {
+            std::lock_guard lock{m_acceptor_mutex};
+            acceptor = m_acceptor;
+        }
+        if(acceptor)
+            acceptor->close();
     }
 
     bool stopped() const
@@ -1130,6 +1166,8 @@ private:
     std::size_t m_max_request_body_size = std::numeric_limits<std::size_t>::max();
     std::size_t m_max_request_head_size = default_max_request_head_size;
     std::atomic<bool> m_stop{false};
+    std::mutex m_acceptor_mutex;
+    std::shared_ptr<net::acceptor> m_acceptor;
 };
 
 } // namespace http

--- a/net/net-http_server.test.c++
+++ b/net/net-http_server.test.c++
@@ -100,6 +100,39 @@ auto register_server_tests()
         };
     };
 
+    tester::bdd::scenario("stop wakes accept wait promptly with no client, [net]") = [] {
+        if(not network_tests_enabled()) return;
+
+        using namespace std::chrono_literals;
+        auto server = std::make_shared<http::server>();
+        server->get("/").text("OK");
+        // Without listen-fd close, stop would wait up to this accept poll.
+        server->timeout(std::chrono::seconds{30});
+
+        std::promise<void> bound;
+        auto bound_future = bound.get_future();
+        std::thread t{[server, &bound] {
+            try
+            {
+                server->listen("127.0.0.1", "0", [&bound] { bound.set_value(); });
+            }
+            catch(...)
+            {
+            }
+        }};
+
+        check_true(bound_future.wait_for(2s) == std::future_status::ready);
+        std::this_thread::sleep_for(50ms);
+        const auto start = std::chrono::steady_clock::now();
+        server->stop();
+        if(t.joinable())
+            t.join();
+        const auto elapsed = std::chrono::steady_clock::now() - start;
+
+        check_true(server->stopped());
+        check_true(elapsed < 500ms);
+    };
+
     tester::bdd::scenario("Structured logging fields in HTTP requests, [net]") = [] {
     if(not network_tests_enabled()) return;
 

--- a/net/net-posix.c++m
+++ b/net/net-posix.c++m
@@ -44,6 +44,7 @@ using ::write;
 using ::recv;
 using ::send;
 using ::close;
+using ::shutdown;
 using ::fcntl;
 using ::socket;
 using ::inet_pton;
@@ -187,6 +188,7 @@ constexpr auto eagain           = EAGAIN;
 constexpr auto eagain           = EWOULDBLOCK; // EAGAIN and EWOULDBLOCK are often the same
 #endif
 constexpr auto eintr            = EINTR;
+constexpr auto ebadf            = EBADF;
 
 inline int get_errno() noexcept { return errno; }
 

--- a/net/net-socket.c++m
+++ b/net/net-socket.c++m
@@ -32,9 +32,19 @@ public:
     }
 
     // Destructor — unchanged
-    ~socket() {
-        if (m_fd != native_handle_npos) {
+    ~socket()
+    {
+        close();
+    }
+
+    // Close the native fd if still open. Safe to call more than once; after
+    // close, conversions to bool are false and the handle is npos.
+    void close() noexcept
+    {
+        if(m_fd != native_handle_npos)
+        {
             posix::close(m_fd);
+            m_fd = native_handle_npos;
         }
     }
 


### PR DESCRIPTION
## Summary
- `http::server::stop()` now closes the active `net::acceptor` listen sockets so a blocked `select`/`accept` wakes immediately instead of waiting for the accept poll (~1s default).
- `net::acceptor::close()` is thread-safe vs `accept()`; post-close wait failures surface as `EBADF` / `"acceptor closed"` (and `EINTR` racing close is treated as stop).
- The listen loop treats those post-stop accept errors as a clean exit (not fatal).

## Why
Docker / container `SIGTERM` handlers that call `server::stop()` and join the listen thread were still delayed by the accept timeout even after #44. #44 fixed the EINTR hang so stop eventually completes; this PR makes stop abort the accept wait promptly.

**Prerequisite:** #44 is already merged on `master`.

## API changes
- `net::socket::close()` — idempotent close of the native fd
- `net::acceptor::close()` / `closed()` — close all listen fds; wake concurrent `accept()`
- `http::server::stop()` — sets stop flag **and** closes the live acceptor
- `net::posix::ebadf`, `posix::shutdown` export (for completeness)

## Tests
- `close wakes accept wait promptly` (acceptor, no client, 30s timeout budget)
- `stop wakes accept wait promptly with no client` (HTTP server)
- Existing net suite still green locally

## Follow-up
YarDB (and fixer) can bump `deps/net` after this lands — not included in this PR.


Made with [Cursor](https://cursor.com)